### PR TITLE
docs: wire changelog page into sidebar and footer

### DIFF
--- a/docs/website/docs/changelog.md
+++ b/docs/website/docs/changelog.md
@@ -1,4 +1,8 @@
-# Changelog
+---
+id: changelog
+title: Changelog
+sidebar_label: Changelog
+---
 
 All notable changes to this project will be documented in this file.
 

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -166,7 +166,7 @@ const config = {
               },
               {
                 label: 'Changelog',
-                href: 'https://github.com/Arubacloud/acloud-github-runner/releases',
+                to: '/next/changelog',
               },
             ],
           },

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -166,7 +166,7 @@ const config = {
               },
               {
                 label: 'Changelog',
-                to: '/next/changelog',
+                to: '/changelog',
               },
             ],
           },

--- a/docs/website/versioned_docs/version-1.0.0/changelog.md
+++ b/docs/website/versioned_docs/version-1.0.0/changelog.md
@@ -1,4 +1,8 @@
-# Changelog
+---
+id: changelog
+title: Changelog
+sidebar_label: Changelog
+---
 
 All notable changes to this project will be documented in this file.
 


### PR DESCRIPTION
The changelog page already existed in the sidebar under Project → Changelog, but two things were missing:

- **Docusaurus frontmatter** (uid=1948168(amedeo.palopoli) gid=1049089 groups=1049089, , ) was absent from , which can cause the doc to render without a proper title
- **Footer link** pointed to the external GitHub Releases page; updated to an internal  route (current docs are served under  while v1.0.0 is the latest released version)

This matches the pattern used in sdk-go and arubacloud-resource-operator.